### PR TITLE
fix: remove .js extension to enable webpacking

### DIFF
--- a/plugin/facebook-handler.android.ts
+++ b/plugin/facebook-handler.android.ts
@@ -1,5 +1,5 @@
 //NativeScript modules
-import applicationModule = require("application");
+import * as applicationModule from "application";
 
 var _isInit: boolean = false;
 var _AndroidApplication = applicationModule.android;

--- a/plugin/facebook-handler.ios.ts
+++ b/plugin/facebook-handler.ios.ts
@@ -1,5 +1,5 @@
 //NativeScript modules
-import applicationModule = require("application");
+import * as applicationModule from "application";
 
 var _isInit: boolean = false;
 
@@ -7,7 +7,7 @@ var mCallbackManager;
 var loginManager;
 
 
-export function init(loginBehavior? : any): boolean { 
+export function init(loginBehavior? : any): boolean {
     //fb initialization
   loginManager = FBSDKLoginManager.alloc().init();
 
@@ -29,11 +29,11 @@ export function init(loginBehavior? : any): boolean {
 export function registerCallback(successCallback: any, cancelCallback: any, failCallback: any) {
     if (_isInit) {
       mCallbackManager= function(result: FBSDKLoginManagerLoginResult, error: NSError) {
-        
+
         if (error) {
           failCallback(error);
           return;
-        } 
+        }
         //something went really wrong no error and no result
         if (!result) {
           failCallback("Null error");

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-facebook-login",
   "version": "0.2.0",
   "description": "A NativeScript module providing Facebook login for Android and iOS",
-  "main": "facebook-handler.js",
+  "main": "facebook-handler",
   "nativescript": {
     "platforms": {
       "android": "1.3.0",


### PR DESCRIPTION
We released a new version of the NS webpack plugin [NS webpack plugin](https://github.com/NativeScript/nativescript-dev-webpack) recently.  That change is necessary for all NativeScript plugins to be compatible with it. The `.js` extension of the `main` property in the `package.json` should be removed. That way, webpack will be able to correctly reference the android or ios main file.

Check out the [Webpack article](http://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson) in the NativeScript  documentation. 